### PR TITLE
feat: add colors to the tab bar

### DIFF
--- a/rio.tera
+++ b/rio.tera
@@ -22,9 +22,12 @@ yellow           = '#{{ yellow.hex }}'
 
 # UI colors
 tabs             = '#{{ base.hex }}'
+tabs-foreground  = '#{{ text.hex }}'
 tabs-active      = '#{{ lavender.hex }}'
-selection-foreground = '#{{ base.hex }}'
-selection-background = '#{{ rosewater.hex }}'
+tabs-active-highlight  = '#{{ lavender.hex }}'
+tabs-active-foreground = '#{{ crust.hex }}'
+selection-foreground   = '#{{ base.hex }}'
+selection-background   = '#{{ rosewater.hex }}'
 
 # Dim colors
 dim-black        = '#{{ surface1.hex }}'

--- a/themes/catppuccin-frappe.toml
+++ b/themes/catppuccin-frappe.toml
@@ -15,9 +15,12 @@ yellow           = '#e5c890'
 
 # UI colors
 tabs             = '#303446'
+tabs-foreground  = '#c6d0f5'
 tabs-active      = '#babbf1'
-selection-foreground = '#303446'
-selection-background = '#f2d5cf'
+tabs-active-highlight  = '#babbf1'
+tabs-active-foreground = '#232634'
+selection-foreground   = '#303446'
+selection-background   = '#f2d5cf'
 
 # Dim colors
 dim-black        = '#51576d'

--- a/themes/catppuccin-latte.toml
+++ b/themes/catppuccin-latte.toml
@@ -15,9 +15,12 @@ yellow           = '#df8e1d'
 
 # UI colors
 tabs             = '#eff1f5'
+tabs-foreground  = '#4c4f69'
 tabs-active      = '#7287fd'
-selection-foreground = '#eff1f5'
-selection-background = '#dc8a78'
+tabs-active-highlight  = '#7287fd'
+tabs-active-foreground = '#dce0e8'
+selection-foreground   = '#eff1f5'
+selection-background   = '#dc8a78'
 
 # Dim colors
 dim-black        = '#bcc0cc'

--- a/themes/catppuccin-macchiato.toml
+++ b/themes/catppuccin-macchiato.toml
@@ -15,9 +15,12 @@ yellow           = '#eed49f'
 
 # UI colors
 tabs             = '#24273a'
+tabs-foreground  = '#cad3f5'
 tabs-active      = '#b7bdf8'
-selection-foreground = '#24273a'
-selection-background = '#f4dbd6'
+tabs-active-highlight  = '#b7bdf8'
+tabs-active-foreground = '#181926'
+selection-foreground   = '#24273a'
+selection-background   = '#f4dbd6'
 
 # Dim colors
 dim-black        = '#494d64'

--- a/themes/catppuccin-mocha.toml
+++ b/themes/catppuccin-mocha.toml
@@ -15,9 +15,12 @@ yellow           = '#f9e2af'
 
 # UI colors
 tabs             = '#1e1e2e'
+tabs-foreground  = '#cdd6f4'
 tabs-active      = '#b4befe'
-selection-foreground = '#1e1e2e'
-selection-background = '#f5e0dc'
+tabs-active-highlight  = '#b4befe'
+tabs-active-foreground = '#11111b'
+selection-foreground   = '#1e1e2e'
+selection-background   = '#f5e0dc'
 
 # Dim colors
 dim-black        = '#45475a'


### PR DESCRIPTION
#### Not every possible tab bar color is set currently so Rio uses default ones, but they look a little bit odd

![image](https://github.com/user-attachments/assets/14b3fb68-a03a-4d5c-aea4-3b5d8306e94d)


#### I added some colors so the tab bar is more consistent with theme now

![image](https://github.com/user-attachments/assets/968a7647-b6af-48d2-8427-0dbd56b64de9)
