### PR TITLE
Fix link in usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ## Usage
 
 1. Download your flavor of choice from [`themes/`](./themes/) to [Rio's theme directory](https://rioterm.com/docs/config#theme).
-2. Edit your [Rio configuration file](https://raphamorim.io/rio/docs/config) and set `theme` to `catppuccin-<flavor>` (or simply the filename minus the extension of the file you previously downloaded).
+2. Edit your [Rio configuration file](https://rioterm.com/docs/config) and set `theme` to `catppuccin-<flavor>` (or simply the filename minus the extension of the file you previously downloaded).
 3. Save your changes.
 
 ## 💝 Thanks to


### PR DESCRIPTION
Rio maintainer has changed the docs base link to [rioterm](https://rioterm.com).